### PR TITLE
HardwareSerial: fix issue with swapping pins twice

### DIFF
--- a/cores/esp8266/HardwareSerial.cpp
+++ b/cores/esp8266/HardwareSerial.cpp
@@ -35,10 +35,10 @@ HardwareSerial::HardwareSerial(int uart_nr)
     : _uart_nr(uart_nr), _rx_size(256)
 {}
 
-void HardwareSerial::begin(unsigned long baud, SerialConfig config, SerialMode mode, uint8_t tx_pin)
+void HardwareSerial::begin(unsigned long baud, SerialConfig config, SerialMode mode, int tx_pin, int rx_pin)
 {
     end();
-    _uart = uart_init(_uart_nr, baud, (int) config, (int) mode, tx_pin, _rx_size);
+    _uart = uart_init(_uart_nr, baud, (int) config, (int) mode, tx_pin, rx_pin, _rx_size);
 }
 
 void HardwareSerial::end()
@@ -62,15 +62,15 @@ size_t HardwareSerial::setRxBufferSize(size_t size){
     return _rx_size;
 }
 
-void HardwareSerial::swap(uint8_t tx_pin)
+void HardwareSerial::swap()
 {
     if(!_uart) {
         return;
     }
-    uart_swap(_uart, tx_pin);
+    uart_swap(_uart);
 }
 
-void HardwareSerial::set_tx(uint8_t tx_pin)
+void HardwareSerial::set_tx(int tx_pin)
 {
     if(!_uart) {
         return;
@@ -78,7 +78,7 @@ void HardwareSerial::set_tx(uint8_t tx_pin)
     uart_set_tx(_uart, tx_pin);
 }
 
-void HardwareSerial::pins(uint8_t tx, uint8_t rx)
+void HardwareSerial::pins(int tx, int rx)
 {
     if(!_uart) {
         return;

--- a/cores/esp8266/HardwareSerial.h
+++ b/cores/esp8266/HardwareSerial.h
@@ -72,40 +72,36 @@ public:
 
     void begin(unsigned long baud)
     {
-        begin(baud, SERIAL_8N1, SERIAL_FULL, 1);
+        begin(baud, SERIAL_8N1, SERIAL_FULL, -1, -1);
     }
     void begin(unsigned long baud, SerialConfig config)
     {
-        begin(baud, config, SERIAL_FULL, 1);
+        begin(baud, config, SERIAL_FULL, -1, -1);
     }
     void begin(unsigned long baud, SerialConfig config, SerialMode mode)
     {
-        begin(baud, config, mode, 1);
+        begin(baud, config, mode, -1, -1);
     }
 
-    void begin(unsigned long baud, SerialConfig config, SerialMode mode, uint8_t tx_pin);
+    void begin(unsigned long baud, SerialConfig config, SerialMode mode, int tx_pin, int rx_pin);
 
     void end();
 
     size_t setRxBufferSize(size_t size);
 
-    void swap()
-    {
-        swap(1);
-    }
-    void swap(uint8_t tx_pin);    //toggle between use of GPIO13/GPIO15 or GPIO3/GPIO(1/2) as RX and TX
+    void swap();    //toggle between use of GPIO13/GPIO15 or GPIO3/GPIO1 as RX and TX
 
     /*
-     * Toggle between use of GPIO1 and GPIO2 as TX on UART 0.
+     * Set TX pin. On UART0, either GPIO1 or GPIO2 can be used.
      * Note: UART 1 can't be used if GPIO2 is used with UART 0!
      */
-    void set_tx(uint8_t tx_pin);
+    void set_tx(int tx_pin);
 
     /*
      * UART 0 possible options are (1, 3), (2, 3) or (15, 13)
      * UART 1 allows only TX on 2 if UART 0 is not (2, 3)
      */
-    void pins(uint8_t tx, uint8_t rx);
+    void pins(int tx, int rx);
 
     int available(void) override;
     int peek(void) override;

--- a/cores/esp8266/core_esp8266_main.cpp
+++ b/cores/esp8266/core_esp8266_main.cpp
@@ -147,20 +147,19 @@ extern "C" void __gdb_do_break(){}
 extern "C" void gdb_do_break(void) __attribute__ ((weak, alias("__gdb_do_break")));
 
 void init_done() {
-    system_set_os_print(1);
     gdb_init();
     do_global_ctors();
-    printf("\n%08x\n", core_version);
     esp_schedule();
 }
 
+extern "C" void uart0_wait_tx_empty();
 
 extern "C" void user_init(void) {
     struct rst_info *rtc_info_ptr = system_get_rst_info();
     memcpy((void *) &resetInfo, (void *) rtc_info_ptr, sizeof(resetInfo));
-
+    uart0_wait_tx_empty();
     uart_div_modify(0, UART_CLK_FREQ / (115200));
-
+    
     init();
 
     initVariant();

--- a/cores/esp8266/uart.h
+++ b/cores/esp8266/uart.h
@@ -113,10 +113,10 @@ extern "C" {
 struct uart_;
 typedef struct uart_ uart_t;
 
-uart_t* uart_init(int uart_nr, int baudrate, int config, int mode, int tx_pin, size_t rx_size);
+uart_t* uart_init(int uart_nr, int baudrate, int config, int mode, int tx_pin, int rx_pin, size_t rx_size);
 void uart_uninit(uart_t* uart);
 
-void uart_swap(uart_t* uart, int tx_pin);
+void uart_swap(uart_t* uart);
 void uart_set_tx(uart_t* uart, int tx_pin);
 void uart_set_pins(uart_t* uart, int tx, int rx);
 bool uart_tx_enabled(uart_t* uart);


### PR DESCRIPTION
Previously calling HardwareSerial::swap twice would set the pins back
to the original setting (1, 3). This feature was lost when swap function
got an optional argument for the TX pin. This change reverts that,
restoring ability to swap pins back.
To use TX pin 2, HardwareSerial::pins or HardwareSerial::set_tx methods
can be used.
This change also simplifies UART pin configuration code.